### PR TITLE
Make possible compilation on Debian stretch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(kdevkernel)
 find_package(KDE4 4.7.0 REQUIRED)
 find_package(KDevPlatform 1.2.60 REQUIRED)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC")
 
 include_directories(
     ${KDE4_INCLUDES}


### PR DESCRIPTION
`-fPIC` is needed because of the way the qt libraries are built for Debian. 

From the build error message:

```
You must build your code with position independent code if Qt was built with -reduce-relocations. " "Compile your code with -fPIC (-fPIE is not enough)
."
```
