### PR TITLE
Set correct install path for Debian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,7 @@
+set(SERVICES_INSTALL_DIR /usr/share/kde4/services)
+set(DATA_INSTALL_DIR /usr/share/kde4/apps)
+set(PLUGIN_INSTALL_DIR /usr/lib/kde4)
+
 project(kdevkernel)
 
 find_package(KDE4 4.7.0 REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(kdevkernel)
 find_package(KDE4 4.7.0 REQUIRED)
 find_package(KDevPlatform 1.2.60 REQUIRED)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -fPIC")
 
 include_directories(
     ${KDE4_INCLUDES}


### PR DESCRIPTION
Of course this breaks the setup for fedora or other distros.

Therefore this commit is more a quick and dirty solution for debian users 
or advanced issue report. 

For a robust solution detection of the right install path would be necesarry.
